### PR TITLE
spreg 1.8.5 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,11 @@ requirements:
     # introduce upper bound:
     # spreg/tests/test_sputils.py::Test_Sparse_Utils::test_multiply - AssertionError: <Compressed Sparse Row sparse matrix of dtype 'float64'
 	  # with 7 stored elements and shape (20, 20)> is not an instance of <class 'scipy.sparse._csc.csc_matrix'>
-    - scipy >=0.11,<1.16  # [py>39 and py<314]
+    - scipy >=0.11,<1.16  # [py<314]
     - scipy >=0.11  # [py>=314]
-    - numpy >=1.23
+    # https://github.com/pysal/spreg/issues/191
+    # Error: TypeError: only 0-dimensional arrays can be converted to Python scalars.
+    - numpy >=1.23,<=2.3.5
     - pandas
     # upstream pins to 4.0.0; increase min bound to 4.8.0 where graphs APIs (used
     # by this package) was introduced to libpysal
@@ -49,9 +51,6 @@ test:
     - pip
     - pytest
     - geopandas
-    # https://github.com/pysal/spreg/issues/191
-    # Error: TypeError: only 0-dimensional arrays can be converted to Python scalars.
-    - numpy <=2.3.5
 
 about:
   home: https://github.com/pysal/spreg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,9 @@ test:
     - pip
     - pytest
     - geopandas
+    # https://github.com/pysal/spreg/issues/191
+    # Error: TypeError: only 0-dimensional arrays can be converted to Python scalars.
+    - numpy <=2.3.5
 
 about:
   home: https://github.com/pysal/spreg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "spreg" %}
-{% set version = "1.8.3" %}
+{% set version = "1.8.5" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/pysal/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3c6a6ffcd348d578cfea72e7e083fe6ff77085d4a779d16f91928ccbf08b5e52
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9cc7ad977a4056ab8f888d6cd1b2ed9d0723537814ff566ae5940fa8eab827f3
 
 build:
   number: 0
@@ -30,7 +30,6 @@ requirements:
     # spreg/tests/test_sputils.py::Test_Sparse_Utils::test_multiply - AssertionError: <Compressed Sparse Row sparse matrix of dtype 'float64'
 	  # with 7 stored elements and shape (20, 20)> is not an instance of <class 'scipy.sparse._csc.csc_matrix'>
     - scipy >=0.11,<1.16  # [py>=310]
-    - scipy >=0.11,<1.12  # [py<310]
     - numpy >=1.23
     - pandas
     # upstream pins to 4.0.0; increase min bound to 4.8.0 where graphs APIs (used
@@ -38,25 +37,17 @@ requirements:
     - libpysal >=4.8.0  #  [py>=310]
     - scikit-learn >=0.22
 
-{% set deselect_tests = "" %}
-
-# tolerance error: Not equal to tolerance rtol=1e-07, atol=0
-{% set deselect_tests = deselect_tests + " --deselect=spreg/tests/test_ml_error_regimes.py::TestMLError::test_model2" %} # [py<310 or (osx and x86_64)]
-
 test:
   imports:
     - spreg
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest --pyargs spreg
   requires:
     - pip
     - pytest
     - geopandas
-  source_files:
-    # tests not in the wheel
-    - spreg/tests
-  commands:
-    - pip check
-    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -vv {{ deselect_tests }}
 
 about:
   home: https://github.com/pysal/spreg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,8 @@ requirements:
     # introduce upper bound:
     # spreg/tests/test_sputils.py::Test_Sparse_Utils::test_multiply - AssertionError: <Compressed Sparse Row sparse matrix of dtype 'float64'
 	  # with 7 stored elements and shape (20, 20)> is not an instance of <class 'scipy.sparse._csc.csc_matrix'>
-    - scipy >=0.11,<1.16  # [py>=310]
+    - scipy >=0.11,<1.16  # [py>39 and py<314]
+    - scipy >=0.11  # [py>=314]
     - numpy >=1.23
     - pandas
     # upstream pins to 4.0.0; increase min bound to 4.8.0 where graphs APIs (used


### PR DESCRIPTION
spreg 1.8.5 

**Destination channel:** Defaults

### Links

- [PKG-12682]
- dev_url:        https://github.com/pysal/spreg/tree/v1.8.5
- conda_forge:    https://github.com/conda-forge/spreg-feedstock
- pypi:           https://pypi.org/project/spreg/1.8.5
- pypi inspector: https://inspector.pypi.io/project/spreg/1.8.5

### Explanation of changes:

- new version number


[PKG-12682]: https://anaconda.atlassian.net/browse/PKG-12682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ